### PR TITLE
Improve non-existent projects behaviour

### DIFF
--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -97,6 +97,11 @@ class Msbuild extends ConventionTask {
     }
 
     def parseProjectFile(def file) {
+        logger.info "Parsing file $file ..."
+        if (!new File(file.toString()).exists()) {
+            throw new GradleException("Project/Solution file $file does not exist")
+        }
+
         def tmp = File.createTempFile('ProjectFileParser', '.exe')
         try {
             def src = getClass().getResourceAsStream(resolver.getFileParserPath())

--- a/src/test/groovy/com/ullink/MsbuildPluginTest.groovy
+++ b/src/test/groovy/com/ullink/MsbuildPluginTest.groovy
@@ -1,13 +1,17 @@
 package com.ullink
 import groovy.xml.MarkupBuilder
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 
 import static org.junit.Assert.assertTrue
 
-
 class MsbuildPluginTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void msbuildPluginAddsMsbuildTaskToProject() {
@@ -34,6 +38,19 @@ class MsbuildPluginTest {
         p.msbuild {
             projectFile = file
         }
+        p.tasks.msbuild.execute()
+    }
+    @Test
+    public void execution_nonExistentProjectFile_throwsGradleException() {
+        Project p = ProjectBuilder.builder().build()
+        p.apply plugin: 'msbuild'
+        p.msbuild {
+            projectFile = "C:\\con" // we can never create a windows file called `con`
+        }
+
+        expectedException.expect(GradleException.class);
+        expectedException.expectMessage("Project/Solution file C:\\con does not exist")
+
         p.tasks.msbuild.execute()
     }
 }


### PR DESCRIPTION
On JDK6 if we don't have a project file, the entire gradle build hangs because the ProjectFileParser cannot write all the stacktrace. This PR fixes that by consuming all stderr.