### PR TITLE
ProjectFileParser is now extracted in the plugin temp dir

### DIFF
--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -102,7 +102,7 @@ class Msbuild extends ConventionTask {
             throw new GradleException("Project/Solution file $file does not exist")
         }
 
-        def tmp = File.createTempFile('ProjectFileParser', '.exe')
+        File tmp = File.createTempFile('ProjectFileParser', '.exe', temporaryDir)
         try {
             def src = getClass().getResourceAsStream(resolver.getFileParserPath())
             tmp.newOutputStream().leftShift(src).close();


### PR DESCRIPTION
Proposition for Issue #28
Following discussion in my previous pull request https://github.com/Ullink/gradle-msbuild-plugin/pull/29
