### PR TITLE
Solution file parsing removed for empty projectName

### DIFF
--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -131,12 +131,12 @@ class Msbuild extends ConventionTask {
     boolean resolveProject() {
         if (projectParsed == null && parseProject) {
             if (isSolutionBuild()) {
-                def result = parseProjectFile(getSolutionFile())
-                allProjects = result.collectEntries { [it.key, new ProjectFileParser(msbuild: this, eval: it.value)] }
                 def projectName = getProjectName()
                 if (projectName == null || projectName.isEmpty()) {
                     parseProject = false
                 } else {
+                    def result = parseProjectFile(getSolutionFile())
+                    allProjects = result.collectEntries { [it.key, new ProjectFileParser(msbuild: this, eval: it.value)] }
                     projectParsed = allProjects[projectName]
                     if (projectParsed == null) {
                         parseProject = false


### PR DESCRIPTION
In issue https://github.com/Ullink/gradle-msbuild-plugin/issues/31 : Warning message: Project XXX found in solution, disabling input/output optimizations

I have a committed a fix to avoid the warning message when the projectName is null, i.e. when we want to build the whole solution.

 In the fix, we still continue to parse the solution file even if the projectName is null. I have corrected it in the current pull request. Now, if the projectName is null, we don't parse the solution file and there is no input/output optimization.
