### PR TITLE
Improvements

### DIFF
--- a/src/main/groovy/com/ullink/IExecutableResolver.groovy
+++ b/src/main/groovy/com/ullink/IExecutableResolver.groovy
@@ -1,8 +1,6 @@
 package com.ullink
 
 interface IExecutableResolver {
-    static final ArrayList<String> KNOWN_VERSIONS = ["4.0", "3.5", "2.0"]
-
     ProcessBuilder executeDotNet(File exe)
 
     void setupExecutable(Msbuild msbuild);

--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -40,11 +40,6 @@ class Msbuild extends ConventionTask {
         resolver =
                 OperatingSystem.current().windows ? new MsbuildResolver() : new XbuildResolver()
 
-        resolver.setupExecutable(this)
-
-        if (msbuildDir == null) {
-            throw new StopActionException("$executable not found")
-        }
         conventionMapping.map "solutionFile", {
             project.file(project.name + ".sln").exists() ? project.name + ".sln" : null
         }
@@ -163,6 +158,11 @@ class Msbuild extends ConventionTask {
     }
 
     def getCommandLineArgs() {
+        resolver.setupExecutable(this)
+
+        if (msbuildDir == null) {
+            throw new StopActionException("$executable not found")
+        }
         def commandLineArgs = [new File(msbuildDir, executable)]
 
         commandLineArgs += '/nologo'

--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -1,10 +1,8 @@
 package com.ullink
-
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import org.gradle.api.GradleException
 import org.gradle.api.internal.ConventionTask
-import org.gradle.api.tasks.StopActionException
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskOutputs
 import org.gradle.internal.os.OperatingSystem
@@ -161,7 +159,7 @@ class Msbuild extends ConventionTask {
         resolver.setupExecutable(this)
 
         if (msbuildDir == null) {
-            throw new StopActionException("$executable not found")
+            throw new GradleException("$executable not found")
         }
         def commandLineArgs = [new File(msbuildDir, executable)]
 

--- a/src/main/groovy/com/ullink/MsbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/MsbuildResolver.groovy
@@ -1,23 +1,41 @@
 package com.ullink
 
+import static java.lang.Float.parseFloat
+
 class MsbuildResolver implements IExecutableResolver {
     static final String MSBUILD_TOOLS_PATH = 'MSBuildToolsPath'
     static final String MSBUILD_PREFIX = "SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions\\"
     static final String MSBUILD_WOW6432_PREFIX = "SOFTWARE\\Wow6432Node\\Microsoft\\MSBuild\\ToolsVersions\\"
 
     void setupExecutable(Msbuild msbuild) {
-        (msbuild.version == null ?
-            KNOWN_VERSIONS :
-            [msbuild.version]).find { x ->
-            trySetMsbuild(msbuild, MSBUILD_WOW6432_PREFIX + x) ||
-                trySetMsbuild(msbuild, MSBUILD_PREFIX + x)
+        List<String> availableVersions =
+                getMsBuildVersionsFromRegistry(MSBUILD_WOW6432_PREFIX) +
+                getMsBuildVersionsFromRegistry(MSBUILD_PREFIX)
+        msbuild.logger.debug("Found following MSBuild versions in the registry: ${availableVersions}")
+
+        List<String> versionsToCheck
+        if (msbuild.version != null) {
+            versionsToCheck = [ MSBUILD_WOW6432_PREFIX + msbuild.version, MSBUILD_PREFIX + msbuild.version ]
+            msbuild.logger.info("MSBuild version explicitly set to: '${msbuild.version}'")
+        } else {
+            versionsToCheck = availableVersions
         }
+
+        if (versionsToCheck.find( { trySetMsbuild(msbuild, it) } ))
+            msbuild.logger.info("Resolved MSBuild to ${msbuild.msbuildDir}")
+        else
+            msbuild.logger.warn("Couldn't resolve MSBuild in the system (existing versions: ${availableVersions}).")
+
         msbuild.executable = 'msbuild.exe'
     }
 
     @Override
     ProcessBuilder executeDotNet(File exe) {
         return new ProcessBuilder(exe.toString())
+    }
+
+    static List<String> getMsBuildVersionsFromRegistry(String key) {
+        Registry.getKeys(Registry.HKEY_LOCAL_MACHINE, key).sort({ -parseFloat(it) }).collect({ key + it })
     }
 
     static boolean trySetMsbuild(Msbuild msbuild, String key) {

--- a/src/main/groovy/com/ullink/Registry.groovy
+++ b/src/main/groovy/com/ullink/Registry.groovy
@@ -7,7 +7,7 @@ import com.sun.jna.platform.win32.WinReg.HKEY
 class Registry {
     static boolean supported
     static HKEY HKEY_LOCAL_MACHINE
-    
+
     static {
         String prev = System.properties['jna.boot.library.name']
         System.properties['jna.boot.library.name'] = 'jnadispatchmsbuild'
@@ -23,7 +23,7 @@ class Registry {
             System.properties.remove('jna.boot.library.name')
         }
     }
-    
+
     static HKEY getHkey(String name) {
         if (!supported) {
             return null
@@ -34,7 +34,19 @@ class Registry {
             return null
         }
     }
-    
+
+    static String[] getKeys(HKEY hkey, String node) {
+        if (!supported) {
+            return null
+        }
+
+        try {
+            return Advapi32Util.registryGetKeys(hkey, node)
+        } catch (ignored) {
+            return null
+        }
+    }
+
     static String getValue(HKEY hkey, String node, String name) {
         if (!supported) {
             return null

--- a/src/main/groovy/com/ullink/XbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/XbuildResolver.groovy
@@ -3,6 +3,7 @@ package com.ullink
 import org.gradle.api.tasks.StopActionException
 
 class XbuildResolver implements IExecutableResolver {
+    static final ArrayList<String> KNOWN_VERSIONS = ["4.0", "3.5", "2.0"]
 
     XbuildResolver(){
         def execute = "mono --version".execute()
@@ -30,7 +31,7 @@ class XbuildResolver implements IExecutableResolver {
         monoRoot = monoRoot - "/bin/mono\n"
 
         def versions = version == null ?
-            IExecutableResolver.KNOWN_VERSIONS :
+            KNOWN_VERSIONS :
             [version]
 
         for (v in versions) {


### PR DESCRIPTION
* Lazy resolving of msbuild ensures proper take in account of the set `version` field
* Generic windows msbuild resolving, without the need for hardcoding the versions.
* Also, most important: I've changed from a StopException to a normal GradleException. It doesn't make sense to mark the task as successful if it didn't find msbuild IMO. Or is there a specific reason for that?

Will get back soon (in another PR) with the unix/os x generic resolving of xbuild :)