### PR TITLE
Use Evaluation.Project to parse project file

### DIFF
--- a/src/main/dotnet/FileUtilities.cs
+++ b/src/main/dotnet/FileUtilities.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProjectFileParser
+{
+    /// <summary>
+    /// Helper that do reflection over Microsoft.Build.Shared.FileUtilities.ItemSpecModifiers
+    /// to retrieve all const fields
+    /// </summary>
+    public static class FileUtilities
+    {
+        static readonly Type s_FileUtilities;
+        public static readonly IEnumerable<string> ItemSpecModifiers;
+        private static readonly Type s_ItemSpecModifiers;
+
+        static FileUtilities()
+        {
+            s_FileUtilities = Type.GetType("Microsoft.Build.Shared.FileUtilities, Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false, false);
+            s_ItemSpecModifiers = s_FileUtilities.GetNestedType("ItemSpecModifiers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            ItemSpecModifiers = s_ItemSpecModifiers.GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).Where(field => field.IsLiteral && !field.IsInitOnly).Select(field => field.GetValue(null) as string).ToList();
+        }
+    }
+}

--- a/src/main/dotnet/PlatformProjectHelper.cs
+++ b/src/main/dotnet/PlatformProjectHelper.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Build.BuildEngine;
+using Microsoft.Build.Evaluation;
 using ProjectFileParser.platform_helpers;
+using ProjectFileParser.solutionparser;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace ProjectFileParser
 {
@@ -26,23 +27,34 @@ namespace ProjectFileParser
             }
         }
 
-        public IEnumerable<BuildItem> GetBuildLevelItems(Project project)
-        {
-            return GetEvaluatedItemsByName(project, false).Where(entry => entry.Item1.StartsWith("BuildLevel")).SelectMany(entry => entry.Item2);
-        }
-
-        public virtual IDisposable Load(Project project, string file)
+        public virtual IDisposable Load(ProjectCollection collection, string file)
         {
             var backup = Directory.GetCurrentDirectory();
             Directory.SetCurrentDirectory(Path.GetDirectoryName(Path.GetFullPath(file)));
-            project.Load(Path.GetFileName(file));
+            foreach (var currentProjectFile in RetrieveProjects(file))
+            {
+                collection.LoadProject(currentProjectFile);
+            }
             return Disposable.Create(() => Directory.SetCurrentDirectory(backup));
         }
 
-        public abstract IEnumerable<Tuple<string, IEnumerable<BuildItem>>> GetEvaluatedItemsByName(Project project, bool ignoreCondition);
+        private IEnumerable<string> RetrieveProjects(string file)
+        {
+            IEnumerable<string> projects = Enumerable.Empty<string>();
+            if (Program.EndingWithSln)
+                return new Solution(file).ProjectsInOrder.Where(proj => proj.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat).Select(proj => proj.RelativePath);
+            else
+                return new[] { file };
+        }
+
+        public abstract IEnumerable<Tuple<string, IEnumerable<ProjectItem>>> GetEvaluatedItemsByName(Microsoft.Build.Evaluation.Project project, bool ignoreCondition);
+
+        public abstract IEnumerable<Tuple<string, IEnumerable<BuildItem>>> GetEvaluatedItemsByName(Microsoft.Build.BuildEngine.Project project, bool ignoreCondition);
+
+        public abstract IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(ProjectItem proj);
 
         public abstract IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(BuildItem proj);
 
-        public abstract void AddNewItem(Project project, string name, string include);
+        public abstract void AddNewItem(Microsoft.Build.BuildEngine.Project project, string name, string include);
     }
 }

--- a/src/main/dotnet/ProjectFileParser.csproj
+++ b/src/main/dotnet/ProjectFileParser.csproj
@@ -37,11 +37,12 @@
     <StartupObject>ProjectFileParser.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -51,6 +52,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Disposable.cs" />
+    <Compile Include="FileUtilities.cs" />
+    <Compile Include="solutionparser\ProjectConfigurationInSolution.cs" />
+    <Compile Include="solutionparser\Solution.cs" />
+    <Compile Include="solutionparser\SolutionProject.cs" />
+    <Compile Include="solutionparser\SolutionProjectType.cs" />
     <Compile Include="platform-helpers\Reflection.cs" />
     <Compile Include="PlatformProjectHelper.cs" />
     <Compile Include="platform-helpers\MsbuildPlatform.cs" />

--- a/src/main/dotnet/ProjectFileParser.csproj
+++ b/src/main/dotnet/ProjectFileParser.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,14 +41,13 @@
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.XML" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Disposable.cs" />

--- a/src/main/dotnet/packages.config
+++ b/src/main/dotnet/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILRepack" version="1.26.0" targetFramework="net4" userInstalled="true" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" userInstalled="true" />
+  <package id="ILRepack" version="1.26.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>

--- a/src/main/dotnet/platform-helpers/MonoPlatform.cs
+++ b/src/main/dotnet/platform-helpers/MonoPlatform.cs
@@ -27,12 +27,17 @@ namespace ProjectFileParser.platform_helpers
 
         public override IEnumerable<Tuple<string, IEnumerable<Microsoft.Build.Evaluation.ProjectItem>>> GetEvaluatedItemsByName(Microsoft.Build.Evaluation.Project project, bool ignoreCondition)
         {
-            throw new NotImplementedException();
+            return project.ItemsIgnoringCondition.GroupBy(item => item.ItemType).Select(g => Tuple.Create(g.Key, g.Cast<Microsoft.Build.Evaluation.ProjectItem>()));
         }
 
-        public override IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(Microsoft.Build.Evaluation.ProjectItem proj)
+        public override IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(Microsoft.Build.Evaluation.ProjectItem item)
         {
-            throw new NotImplementedException();
+            var fileUtilesMetadata = FileUtilities.ItemSpecModifiers.Where(itemSpecMetadata => item.HasMetadata(itemSpecMetadata)).Select(itemSpecMetadata => new Tuple<string, string>(itemSpecMetadata, item.GetMetadataValue(itemSpecMetadata)));
+
+            return item.Metadata
+                .Select(metadata => new Tuple<string, string>(metadata.ItemType, metadata.EvaluatedValue))
+                .Union(fileUtilesMetadata)
+                .Where(tuple => !string.IsNullOrEmpty(tuple.Item2));
         }
     }
 }

--- a/src/main/dotnet/platform-helpers/MonoPlatform.cs
+++ b/src/main/dotnet/platform-helpers/MonoPlatform.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using Microsoft.Build.BuildEngine;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Build.BuildEngine;
-using System.Collections;
 
 namespace ProjectFileParser.platform_helpers
 {
@@ -23,6 +23,16 @@ namespace ProjectFileParser.platform_helpers
         {
             var dic = Reflection.GetField<IDictionary, BuildItem>(proj, "evaluatedMetadata");
             return dic.Cast<DictionaryEntry>().Select(e => Tuple.Create((string)e.Key, (string)e.Value));
+        }
+
+        public override IEnumerable<Tuple<string, IEnumerable<Microsoft.Build.Evaluation.ProjectItem>>> GetEvaluatedItemsByName(Microsoft.Build.Evaluation.Project project, bool ignoreCondition)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(Microsoft.Build.Evaluation.ProjectItem proj)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/main/dotnet/platform-helpers/MsbuildPlatform.cs
+++ b/src/main/dotnet/platform-helpers/MsbuildPlatform.cs
@@ -1,134 +1,41 @@
-﻿using System;
+﻿using Microsoft.Build.BuildEngine;
+using Microsoft.Build.Evaluation;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Build.BuildEngine;
-using System.Xml;
-using System.IO;
-using System.Text.RegularExpressions;
 
 namespace ProjectFileParser.platform_helpers
 {
     internal class MsbuildPlatform : PlatformProjectHelper
     {
-        public override void AddNewItem(Project project, string name, string include)
+        public override void AddNewItem(Microsoft.Build.BuildEngine.Project project, string name, string include)
         {
             project.AddNewItem(name, include);
         }
 
-        public override IEnumerable<Tuple<string, IEnumerable<BuildItem>>> GetEvaluatedItemsByName(Project project, bool ignoreCondition)
+        public override IEnumerable<Tuple<string, IEnumerable<ProjectItem>>> GetEvaluatedItemsByName(Microsoft.Build.Evaluation.Project project, bool ignoreCondition)
+        {
+            return project.ItemsIgnoringCondition.GroupBy(item => item.ItemType).Select(g => Tuple.Create(g.Key, g.Cast<ProjectItem>()));
+        }
+
+        public override IEnumerable<Tuple<string, IEnumerable<BuildItem>>> GetEvaluatedItemsByName(Microsoft.Build.BuildEngine.Project project, bool ignoreCondition)
         {
             return (ignoreCondition ? project.EvaluatedItemsIgnoringCondition : project.EvaluatedItems).Cast<BuildItem>().GroupBy(item => item.Name).Select(g => Tuple.Create(g.Key, g.Cast<BuildItem>()));
+        }
+
+        public override IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(ProjectItem item)
+        {
+            var fileUtilesMetadata = FileUtilities.ItemSpecModifiers.Where(itemSpecMetadata => item.HasMetadata(itemSpecMetadata)).Select(itemSpecMetadata => new Tuple<string, string>(itemSpecMetadata, item.GetMetadataValue(itemSpecMetadata)));
+
+            return item.Metadata
+                .Select(metadata => new Tuple<string, string>(metadata.ItemType, metadata.EvaluatedValue))
+                .Union(fileUtilesMetadata)
+                .Where(tuple => !string.IsNullOrEmpty(tuple.Item2));
         }
 
         public override IEnumerable<Tuple<string, string>> GetEvaluatedMetadata(BuildItem proj)
         {
             return proj.MetadataNames.Cast<string>().Select(k => Tuple.Create(k, proj.GetEvaluatedMetadata(k)));
-        }
-
-        public override IDisposable Load(Project project, string file)
-        {
-            try
-            {
-                return base.Load(project, file);
-            }
-            finally
-            {
-                ReplaceThisFileProperties(project);
-            }
-        }
-
-        // MSBuild engine doesn't support newer MSBuildThisFile* properties
-        // Work around that by replacing them with individual per-file global
-        // properties.
-        // Would probably need to go through BuildItems as well, but that's
-        // a first step.
-        private void ReplaceThisFileProperties(Project project)
-        {
-            var dic = new Dictionary<string, string>();
-            foreach (var p in project.PropertyGroups.Cast<BuildPropertyGroup>().SelectMany(g => g.Cast<BuildProperty>()))
-            {
-                var value = TryChangeValue(dic, p, p.Value);
-                if (value != null)
-                    Reflection.Invoke(p, "SetValue", value);
-                value = TryChangeValue(dic, p, p.Condition);
-                if (value != null)
-                {
-                    var xml = Reflection.GetProperty<XmlElement, BuildProperty>(p, "PropertyElement");
-                    xml.SetAttribute("Condition", value);
-                    Reflection.SetField(p, "conditionAttribute", xml.Attributes["Condition"]);
-                    Reflection.Invoke(p, "MarkPropertyAsDirty");
-                }
-            }
-            foreach (var entry in dic)
-            {
-                project.GlobalProperties[entry.Key] = new BuildProperty(entry.Key, entry.Value);
-            }
-        }
-
-        class Mapper
-        {
-            static readonly Regex PathToProperty = new Regex("[^a-zA-Z]+", RegexOptions.Compiled);
-            readonly string suffix, property;
-            readonly Func<string, string> map;
-
-            private Mapper(string suffix, Func<string, string> mapping)
-            {
-                this.suffix = suffix;
-                this.map = mapping;
-                this.property = "MSBuildThisFile" + suffix;
-            }
-
-            public string Map(IDictionary<string, string> extras, BuildProperty p, string value)
-            {
-                if (!value.Contains(property))
-                    return value;
-                var thisFile = map(GetThisFilePath(p));
-                var thisFileProp = "__" + PathToProperty.Replace(thisFile, "") + suffix + "__";
-                extras[thisFileProp] = thisFile;
-                return value.Replace(property, thisFileProp);
-            }
-
-            public static IEnumerable<Mapper> CreateMappers()
-            {
-                yield return new Mapper ( "DirectoryNoRoot", GetDirNoRoot );
-                yield return new Mapper ( "Directory"      , Path.GetDirectoryName );
-                yield return new Mapper ( "FullPath"       , f => f );
-                yield return new Mapper ( "Name"           , Path.GetFileNameWithoutExtension );
-                yield return new Mapper ( "Extension"      , Path.GetExtension );
-                yield return new Mapper ( ""               , Path.GetFileName );
-            }
-
-            private static string GetDirNoRoot(string f)
-            {
-                string dir = f + Path.DirectorySeparatorChar;
-                return dir.Substring(Path.GetPathRoot(dir).Length);
-            }
-        }
-
-        static readonly IEnumerable<Mapper> Mappers = Mapper.CreateMappers().ToList();
-
-        static string TryChangeValue(IDictionary<string, string> extraProps, BuildProperty p, string value)
-        {
-            if (!value.Contains("MSBuildThisFile")) return null;
-            var orig = value;
-            var val = value;
-            while (true)
-            {
-                if (p.Name == "BuildDirectory")
-                foreach (var map in Mappers)
-                {
-                    val = map.Map(extraProps, p, val);
-                }
-                if (val == value) break;
-                value = val;
-            }
-            return val == orig ? null : val;
-        }
-
-        static string GetThisFilePath(BuildProperty p)
-        {
-            var xml = Reflection.GetProperty<XmlElement, BuildProperty>(p, "PropertyElement");
-            return new Uri(xml.BaseURI).LocalPath;
         }
     }
 }

--- a/src/main/dotnet/solutionparser/ProjectConfigurationInSolution.cs
+++ b/src/main/dotnet/solutionparser/ProjectConfigurationInSolution.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Reflection;
+
+namespace ProjectFileParser.solutionparser
+{
+    /// <summary>
+    /// Wrapper class over the internal class Microsoft.Build.Construction.ProjectConfigurationInSolution
+    /// </summary>
+    public class ProjectConfigurationInSolution
+    {
+        static readonly Type s_ProjectConfigurationInSolution;
+        static readonly PropertyInfo s_ProjectConfigurationInSolution_ConfigurationName;
+        static readonly PropertyInfo s_ProjectConfigurationInSolution_FullName;
+        static readonly PropertyInfo s_ProjectConfigurationInSolution_PlatformName;
+        static readonly PropertyInfo s_ProjectConfigurationInSolution_IncludeInBuild;
+
+        static ProjectConfigurationInSolution()
+        {
+            s_ProjectConfigurationInSolution = Type.GetType("Microsoft.Build.Construction.ProjectConfigurationInSolution, Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false, false);
+            if (s_ProjectConfigurationInSolution != null)
+            {
+                s_ProjectConfigurationInSolution_ConfigurationName = s_ProjectConfigurationInSolution.GetProperty("ConfigurationName", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectConfigurationInSolution_FullName = s_ProjectConfigurationInSolution.GetProperty("FullName", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectConfigurationInSolution_PlatformName = s_ProjectConfigurationInSolution.GetProperty("PlatformName", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectConfigurationInSolution_IncludeInBuild = s_ProjectConfigurationInSolution.GetProperty("IncludeInBuild", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+        }
+
+        public string ConfigurationName { get; private set; }
+        public string FullName { get; private set; }
+        public string PlatformName { get; private set; }
+        public bool IncludeInBuild { get; private set; }
+
+        public ProjectConfigurationInSolution(object configurationInSolution)
+        {
+            ConfigurationName = s_ProjectConfigurationInSolution_ConfigurationName.GetValue(configurationInSolution, null) as string;
+            FullName = s_ProjectConfigurationInSolution_FullName.GetValue(configurationInSolution, null) as string;
+            PlatformName = s_ProjectConfigurationInSolution_PlatformName.GetValue(configurationInSolution, null) as string;
+            IncludeInBuild = (bool)s_ProjectConfigurationInSolution_IncludeInBuild.GetValue(configurationInSolution, null);
+        }
+    }
+}

--- a/src/main/dotnet/solutionparser/Solution.cs
+++ b/src/main/dotnet/solutionparser/Solution.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ProjectFileParser.solutionparser
+{
+    /// <summary>
+    /// Wrapper class over the internal Microsoft.Build.Construction.SolutionParser
+    /// </summary>
+    public class Solution
+    {
+        //internal class SolutionParser
+        //Name: Microsoft.Build.Construction.SolutionParser
+        //Assembly: Microsoft.Build, Version=4.0.0.0
+
+        static readonly Type s_SolutionParser;
+        static readonly PropertyInfo s_SolutionParser_solutionReader;
+        static readonly MethodInfo s_SolutionParser_parseSolution;
+        static readonly PropertyInfo s_SolutionParser_projects;
+        static readonly PropertyInfo s_SolutionParser_projectsInOrder;
+        static readonly MethodInfo s_SolutionParser_getDefaultConfigurationName;
+        static readonly MethodInfo s_SolutionParser_getDefaultPlatformName;
+
+        static Solution()
+        {
+            s_SolutionParser = Type.GetType("Microsoft.Build.Construction.SolutionParser, Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false, false);
+            if (s_SolutionParser != null)
+            {
+                s_SolutionParser_solutionReader = s_SolutionParser.GetProperty("SolutionReader", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_SolutionParser_projects = s_SolutionParser.GetProperty("Projects", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_SolutionParser_projectsInOrder = s_SolutionParser.GetProperty("ProjectsInOrder", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_SolutionParser_parseSolution = s_SolutionParser.GetMethod("ParseSolution", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_SolutionParser_getDefaultConfigurationName = s_SolutionParser.GetMethod("GetDefaultConfigurationName", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_SolutionParser_getDefaultPlatformName = s_SolutionParser.GetMethod("GetDefaultPlatformName", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+        }
+
+        public List<SolutionProject> Projects { get; private set; }
+        public List<SolutionProject> ProjectsInOrder { get; private set; }
+        public string DefaultConfigurationName { get; private set; }
+        public string DefaultPlatformName { get; private set; }
+
+        public Solution(string solutionFileName)
+        {
+            if (s_SolutionParser == null)
+            {
+                throw new InvalidOperationException("Can not find type 'Microsoft.Build.Construction.SolutionParser' are you missing a assembly reference to 'Microsoft.Build.dll'?");
+            }
+            var solutionParser = s_SolutionParser.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).First().Invoke(null);
+            using (var streamReader = new StreamReader(solutionFileName))
+            {
+                s_SolutionParser_solutionReader.SetValue(solutionParser, streamReader, null);
+                s_SolutionParser_parseSolution.Invoke(solutionParser, null);
+            }
+            var projects = new List<SolutionProject>();
+            var array = (ArrayList)s_SolutionParser_projectsInOrder.GetValue(solutionParser, null);
+
+            foreach (var entry in array)
+            {
+                projects.Add(new SolutionProject(entry));
+            }
+            this.ProjectsInOrder = projects;
+            this.Projects = projects;
+            this.DefaultConfigurationName = s_SolutionParser_getDefaultConfigurationName.Invoke(solutionParser, null) as string;
+            this.DefaultPlatformName = s_SolutionParser_getDefaultPlatformName.Invoke(solutionParser, null) as string;
+        }
+    }
+}

--- a/src/main/dotnet/solutionparser/SolutionProject.cs
+++ b/src/main/dotnet/solutionparser/SolutionProject.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace ProjectFileParser.solutionparser
+{
+    /// <summary>
+    /// Wrapper class over the internal class Microsoft.Build.Construction.ProjectInSolution
+    /// </summary>
+    [DebuggerDisplay("{ProjectName}, {RelativePath}, {ProjectGuid}")]
+    public class SolutionProject
+    {
+        static readonly Type s_ProjectInSolution;
+        static readonly PropertyInfo s_ProjectInSolution_ProjectName;
+        static readonly PropertyInfo s_ProjectInSolution_RelativePath;
+        static readonly PropertyInfo s_ProjectInSolution_ProjectGuid;
+        static readonly PropertyInfo s_ProjectInSolution_ProjectType;
+        static readonly PropertyInfo s_ProjectInSolution_ProjectConfigurations;
+
+        static SolutionProject()
+        {
+            s_ProjectInSolution = Type.GetType("Microsoft.Build.Construction.ProjectInSolution, Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false, false);
+            if (s_ProjectInSolution != null)
+            {
+                s_ProjectInSolution_ProjectName = s_ProjectInSolution.GetProperty("ProjectName", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectInSolution_RelativePath = s_ProjectInSolution.GetProperty("RelativePath", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectInSolution_ProjectGuid = s_ProjectInSolution.GetProperty("ProjectGuid", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectInSolution_ProjectType = s_ProjectInSolution.GetProperty("ProjectType", BindingFlags.NonPublic | BindingFlags.Instance);
+                s_ProjectInSolution_ProjectConfigurations = s_ProjectInSolution.GetProperty("ProjectConfigurations", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+        }
+
+        public string ProjectName { get; private set; }
+        public string RelativePath { get; private set; }
+        public string ProjectGuid { get; private set; }
+        public SolutionProjectType ProjectType { get; private set; }
+        public Dictionary<string, ProjectConfigurationInSolution> ProjectConfigurations { get; private set; }
+
+        public SolutionProject(object solutionProject)
+        {
+            this.ProjectName = s_ProjectInSolution_ProjectName.GetValue(solutionProject, null) as string;
+            this.RelativePath = s_ProjectInSolution_RelativePath.GetValue(solutionProject, null) as string;
+            this.ProjectGuid = s_ProjectInSolution_ProjectGuid.GetValue(solutionProject, null) as string;
+            this.ProjectType = (SolutionProjectType)Enum.Parse(typeof(SolutionProjectType), s_ProjectInSolution_ProjectType.GetValue(solutionProject, null).ToString());
+            var obj = s_ProjectInSolution_ProjectConfigurations.GetValue(solutionProject, null);
+            var idict = obj as IDictionary;
+            if (idict == null)
+                return;
+            var newDict = new Dictionary<string, ProjectConfigurationInSolution>();
+            foreach (DictionaryEntry entry in idict)
+            {
+                newDict.Add((string)entry.Key, new ProjectConfigurationInSolution(entry.Value));
+            }
+            ProjectConfigurations = newDict;
+        }
+    }
+}

--- a/src/main/dotnet/solutionparser/SolutionProjectType.cs
+++ b/src/main/dotnet/solutionparser/SolutionProjectType.cs
@@ -1,0 +1,15 @@
+﻿namespace ProjectFileParser.solutionparser
+{
+    /// <summary>
+    /// Replication of the internal enum Microsoft.Build.Construction.SolutionProjectType
+    /// </summary>
+    public enum SolutionProjectType
+    {
+        Unknown,
+        KnownToBeMSBuildFormat,
+        SolutionFolder,
+        WebProject,
+        WebDeploymentProject,
+        EtpSubProject
+    }
+}


### PR DESCRIPTION
Instead of using the deprecated Project class that is not compatible
with the msbuild 4.0+ format, we use the non deprecated to allow
parsing of all the new things introduce in the format like the Label
on Import tag.

The parsing of the solution is done by internal class: SolutionParser
A wrapper over all concerned classes has been created.

The serialization of the Solution still use the old method because the
new parser don't give you all the information like the buildOrder.