### PR TITLE
Removed unnecessary check for mono in XbuildResolver constructor

### DIFF
--- a/src/main/groovy/com/ullink/XbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/XbuildResolver.groovy
@@ -5,13 +5,7 @@ import org.gradle.api.GradleException
 import org.gradle.util.VersionNumber
 
 class XbuildResolver implements IExecutableResolver {
-    XbuildResolver(){
-        def execute = "mono --version".execute()
-        execute.waitFor()
-        if (execute.in.text == null)
-            throw new GradleException("Mono must be on PATH.")
-    }
-
+    
     @Override
     ProcessBuilder executeDotNet(File exe) {
         return new ProcessBuilder("mono", exe.toString())


### PR DESCRIPTION
This check will not even allow a gradle project to complete the configuration
phase.

This is particularly problematic for mutli-module projects where only a single
module might require xbuild/msbuild and java developers are unable to run gradle
without install mono.