### PR TITLE
Execute msbuild as a .NET app

### DIFF
--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -137,7 +137,7 @@ class Msbuild extends ConventionTask {
         if (msbuildDir == null) {
             throw new GradleException("$executable not found")
         }
-        def commandLineArgs = [new File(msbuildDir, executable)]
+        def commandLineArgs = resolver.executeDotNet(new File(msbuildDir, executable)).command()
 
         commandLineArgs += '/nologo'
 


### PR DESCRIPTION
On Windows it won't have any effects, as we
execute .exe files directly. On Linux/OS X we need
to invoke them via the mono runtime.

This fixes #46