### PR TITLE
Fix projectParser.name not existing

### DIFF
--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -133,8 +133,9 @@ class Msbuild extends ConventionTask {
                     }
                 }
             } else if (isProjectBuild()) {
-                projectParsed = new ProjectFileParser(msbuild: this, eval: parseProjectFile(getRootedProjectFile()))
-                allProjects[projectParsed.projectName] = projectParsed
+                def result = parseProjectFile(getRootedProjectFile())
+                allProjects = result.collectEntries {[it.key, new ProjectFileParser(msbuild: this, eval: it.value)]}
+                projectParsed = allProjects.values().first()
             }
         }
         projectParsed != null


### PR DESCRIPTION
Json format has changed.
Before, we had

{
    "Compile": [

and now

{
  "project-name": {
    "Compile": [

so projectParser.name could not works