### PR TITLE
Correctly handle Mono installed at 4.5-api

### DIFF
--- a/src/test/groovy/com/ullink/XbuildLocateTest.groovy
+++ b/src/test/groovy/com/ullink/XbuildLocateTest.groovy
@@ -24,9 +24,21 @@ class XbuildLocateTest {
     @Test
     public void testXBuildCanBeFound() {
         def resolver = new XbuildResolver()
+
+        // Unspecified version
         Project p = ProjectBuilder.builder().build()
         p.apply plugin: 'msbuild'
         def xbuildDir = resolver.getXBuildDir(p.tasks.msbuild)
+        assertNotNull(xbuildDir)
+
+        // Specified version
+        p = ProjectBuilder.builder().build()
+        p.apply plugin: 'msbuild'
+        def xbuildVersion = new BigDecimal(new File(xbuildDir).name)
+        p.msbuild {
+            version = xbuildVersion
+        }
+        xbuildDir = resolver.getXBuildDir(p.tasks.msbuild)
         assertNotNull(xbuildDir)
     }
 


### PR DESCRIPTION
Fixes #62 

Note that the existing XBuildResolverTests will fail on a system with Mono 4.4.0 installed, but will not fail otherwise. I did not add an additional test that will always cover this scenario, even on systems with Mono 4.4.0, because doing so would have required a significant refactoring of the XBuildResolver class in order to be able to pass in test paths. If the maintainers would like that refactoring done and the test added, I am happy to do it.

I did notice that the existing tests did not cover the case of an explicitly specified version number, so I modified the existing "XBuildCanBeFound" test to also cover that case.