### PR TITLE
Use last version of JNA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # gradle-msbuild-plugin changelog
 
+## 2.16
+
+### Fixed
+* Registry keys are found when looking for msbuild versions. The issue is related to the JNA version used in other plugins.
+
 ## 2.15
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'nu.studer.plugindev' version '1.0.3'
     id 'com.jfrog.bintray' version '1.2'
-    id 'com.ullink.msbuild' version '2.12'
+    id 'com.ullink.msbuild' version '2.15'
     id 'com.ullink.nuget' version '2.13'
     id 'com.ullink.nunit' version '1.5'
     id 'net.researchgate.release' version '2.3.4'

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ ext.dotnetPath = file('src/main/dotnet')
 dependencies {
     testCompile 'junit:junit:4.11'
     testCompile group: 'org.spockframework', name: 'spock-core', version: '0.7-groovy-2.0', transitive: false
-    compile 'net.java.dev.jna:jna:3.5.0'
-    compile 'net.java.dev.jna:platform:3.5.0'
+    compile 'net.java.dev.jna:jna:4.2.2'
+    compile 'net.java.dev.jna:jna-platform:4.2.2'
     compile 'com.google.guava:guava:16.0.1'
     compile 'commons-io:commons-io:2.4'
 }


### PR DESCRIPTION
Without it I've an exception when getting keys in Windows Registery.
I've the issue when using a plugin which is using jbrowserdriver and
selenium-java.
selenium-java needs at least 4.1.0: http://bit.ly/2dNT2OY
jbrowserdriver seems to exclude it: http://bit.ly/2cPSmCM