### PR TITLE
Downgrade jna to 4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,7 @@ ext.dotnetPath = file('src/main/dotnet')
 dependencies {
     testCompile 'junit:junit:4.11'
     testCompile group: 'org.spockframework', name: 'spock-core', version: '0.7-groovy-2.0', transitive: false
-    compile 'net.java.dev.jna:jna:4.2.2'
-    compile 'net.java.dev.jna:jna-platform:4.2.2'
+    compile 'net.java.dev.jna:jna-platform:4.1.0'
     compile 'com.google.guava:guava:16.0.1'
     compile 'commons-io:commons-io:2.4'
 }


### PR DESCRIPTION
It fails to get registry with jna 4.2.2, with error code returning 6
which is invalid handle when it is invoked from gradle