### PR TITLE
Add AssemblyDescription to AssemblyVersionPatcher

### DIFF
--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -44,8 +44,8 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
 
     @Input
     def informationalVersion
-	
-	@Input
+    
+    @Input
     def assemblyDescription = ''
 
     @Input

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -44,6 +44,9 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
 
     @Input
     def informationalVersion
+	
+	@Input
+    def assemblyDescription = ''
 
     @Input
     def charset = "UTF-8"
@@ -61,6 +64,7 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
             replace(it, 'AssemblyVersion', getVersion())
             replace(it, 'AssemblyFileVersion', getFileVersion())
             replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
+			replace(it, 'AssemblyDescription', getAssemblyDescription())
         }
     }
 

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -64,7 +64,7 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
             replace(it, 'AssemblyVersion', getVersion())
             replace(it, 'AssemblyFileVersion', getFileVersion())
             replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
-			replace(it, 'AssemblyDescription', getAssemblyDescription())
+	    replace(it, 'AssemblyDescription', getAssemblyDescription())
         }
     }
 

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -64,7 +64,7 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
             replace(it, 'AssemblyVersion', getVersion())
             replace(it, 'AssemblyFileVersion', getFileVersion())
             replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
-	    replace(it, 'AssemblyDescription', getAssemblyDescription())
+            replace(it, 'AssemblyDescription', getAssemblyDescription())
         }
     }
 


### PR DESCRIPTION
Add AssemblyDescription to fields that can be patched with the task, so that the description can be provided during build process. If .nuspec file is not used for generating the NuGet package, then the AssemblyDescription is used as a description of a NuGet package. The NuGet package description field is visible when browsing packages and it is important to understand why that particular version of a package was created.