### PR TITLE
Changed AssemblyInfoVersionPatcher so that it won't erase AssemblyDescription if no description is specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # gradle-msbuild-plugin changelog
 
+## 2.19
+
+### Added
+* added support for updating assembly info for `VB.Net` projects in AssemblyInfo.vb files.
+
+### Changed
+* changed the `AssemblyInfoVersionPatcher` so that it will not overwrite values in the AssemblyInfo files if the value being set is blank.  
+* changed NuGet.exe dependency from `2.8.6` to version `4.4.0`
+
 ## 2.18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,12 +75,26 @@ and configure by:
     }
 
     assemblyInfoPatcher {
-      // mandatory if you want to patch your AssemblyInfo.cs/fs
+      // mandatory if you want to patch your AssemblyInfo.cs/fs/vb
+            
+      // replaces the AssemblyVersion value in your AssemblyInfo file.
+      // when explicitly set to blank, AssemblyVersion will not be updated and will keep the existing value in your AssemblyInfo file
       // TODO: not yet normalized, beware than .Net version must be X.Y.Z.B format, with Z/B optionals
       version = project.version + '.0.0'
 
+      // replaces the AssemblyFileVersion value in your AssemblyInfo file.
       // defaults to above version, fewer restrictions on the format
+      // when explicitly set to blank, AssemblyFileVersion will not be updated and will keep the existing value in your AssemblyInfo file
       fileVersion = version + '-Beta'
+      
+      // replaces the AssemblyInformationalVersion value in your AssemblyInfo file.
+      // defaults to above version, fewer restrictions on the format
+      // when explicitly set to blank, AssemblyInformationalVersion will not be updated and will keep the existing value in your AssemblyInfo file
+      informationalVersion = version + '-Beta'
+      
+      // replaces the AssemblyDescription in the your AssemblyInfo file.
+      // when set to blank (default), AssemblyDescription will not be updated and will keep the existing value in your AssemblyInfo file
+      description = 'My Project Description'
 
       // default to msbuild main project (of solution)
       projects = [ 'MyProject1', 'MyProject2' ]

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -61,8 +61,6 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
     void run() {
         getPatchedFiles().each {
             logger.info("Replacing version attributes in $it")
-            //only change the values if they specified in this build script.
-            //if the parameters are blank, then keep whatever is already in the assemblyinfo file.
             replace(it, 'AssemblyVersion', getVersion())
             replace(it, 'AssemblyFileVersion', getFileVersion())
             replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
@@ -71,7 +69,10 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
     }
 
     void replace(def file, def name, def value) {
-		if (!value || value == '') return
+        //only change the assembly values if they specified here (not blank or null)
+        //if the parameters are blank, then keep whatever is already in the assemblyinfo file.
+        if (value == null || value.isEmpty()) return
+    
         if (FilenameUtils.getExtension(file.name) == 'fs')
             project.ant.replaceregexp(file: file, match: /^\[<assembly: $name\s*\(".*"\)\s*>\]$/, replace: "[<assembly: ${name}(\"${value}\")>]", byline: true, encoding: charset)
         else

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -64,7 +64,10 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
             replace(it, 'AssemblyVersion', getVersion())
             replace(it, 'AssemblyFileVersion', getFileVersion())
             replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
-            replace(it, 'AssemblyDescription', getAssemblyDescription())
+			if (getAssemblyDescription() != '') {
+				//only change the description if it is specified in this build script.
+				replace(it, 'AssemblyDescription', getAssemblyDescription())
+			}
         }
     }
 

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -61,13 +61,20 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
     void run() {
         getPatchedFiles().each {
             logger.info("Replacing version attributes in $it")
-            replace(it, 'AssemblyVersion', getVersion())
-            replace(it, 'AssemblyFileVersion', getFileVersion())
-            replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
-			if (getAssemblyDescription() != '') {
-				//only change the description if it is specified in this build script.
-				replace(it, 'AssemblyDescription', getAssemblyDescription())
-			}
+            //only change the values if they specified in this build script.
+            //if the parameters are blank, then keep whatever is already in the assemblyinfo file.
+            if (getVersion() != '') {
+                replace(it, 'AssemblyVersion', getVersion())
+            }
+            if (getFileVersion() != '') {
+                replace(it, 'AssemblyFileVersion', getFileVersion())
+            }
+            if (getInformationalVersion() != '') {
+                replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
+            }
+            if (getAssemblyDescription() != '') {
+                replace(it, 'AssemblyDescription', getAssemblyDescription())
+            }
         }
     }
 

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -63,22 +63,15 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
             logger.info("Replacing version attributes in $it")
             //only change the values if they specified in this build script.
             //if the parameters are blank, then keep whatever is already in the assemblyinfo file.
-            if (getVersion() != '') {
-                replace(it, 'AssemblyVersion', getVersion())
-            }
-            if (getFileVersion() != '') {
-                replace(it, 'AssemblyFileVersion', getFileVersion())
-            }
-            if (getInformationalVersion() != '') {
-                replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
-            }
-            if (getAssemblyDescription() != '') {
-                replace(it, 'AssemblyDescription', getAssemblyDescription())
-            }
+            replace(it, 'AssemblyVersion', getVersion())
+            replace(it, 'AssemblyFileVersion', getFileVersion())
+            replace(it, 'AssemblyInformationalVersion', getInformationalVersion())
+            replace(it, 'AssemblyDescription', getAssemblyDescription())
         }
     }
 
     void replace(def file, def name, def value) {
+		if (!value || value == '') return
         if (FilenameUtils.getExtension(file.name) == 'fs')
             project.ant.replaceregexp(file: file, match: /^\[<assembly: $name\s*\(".*"\)\s*>\]$/, replace: "[<assembly: ${name}(\"${value}\")>]", byline: true, encoding: charset)
         else


### PR DESCRIPTION
Changed AssemblyInfoVersionPatcher so that it won't erase AssemblyDescription if no description is specified.

My solutions have multiple startup projects in them, and if we leave this in, it either overwrites the description to the same value, or it blanks out the description that already exists in the projects.  