### PR TITLE
Added support for setting the assembly info version for VB project files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
 nuget {
     // still experiencing freezes on mono with nuget 3.3.0
-    version = '2.8.6'
+    version = '4.4.0'
 }
 
 nugetRestore {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 }
 
 nuget {
-    // still experiencing freezes on mono with nuget 3.3.0
     version = '4.4.0'
 }
 

--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -71,6 +71,8 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
     void replace(def file, def name, def value) {
         if (FilenameUtils.getExtension(file.name) == 'fs')
             project.ant.replaceregexp(file: file, match: /^\[<assembly: $name\s*\(".*"\)\s*>\]$/, replace: "[<assembly: ${name}(\"${value}\")>]", byline: true, encoding: charset)
+        else if (FilenameUtils.getExtension(file.name) == 'vb')
+            project.ant.replaceregexp(file: file, match: /^<Assembly: $name\s*\(".*"\)\s*>$/, replace: "<Assembly: ${name}(\"${value}\")>", byline: true, encoding: charset)
         else
             project.ant.replaceregexp(file: file, match: /^\[assembly: $name\s*\(".*"\)\s*\]$/, replace: "[assembly: ${name}(\"${value}\")]", byline: true, encoding: charset)
     }


### PR DESCRIPTION
This adds support for replacing the version info on VB projects.  

I also updated the nuget version number because 2.8.6 doesn't work on my system anymore with the newer local version.  I only tested this on Windows.