### PR TITLE
Check vswhere output folder is exist or not

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ task generateZip(dependsOn: nunit, type: Zip) {
 }
 
 task downloadVsWhere(type: de.undercouch.gradle.tasks.download.Download) {
-    src 'https://github.com/Microsoft/vswhere/releases/download/2.3.7/vswhere.exe'
+    src 'https://github.com/Microsoft/vswhere/releases/download/2.4.1/vswhere.exe'
     dest "$temporaryDir/vswhere.exe"
 }
 

--- a/src/main/groovy/com/ullink/MsbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/MsbuildResolver.groovy
@@ -30,13 +30,17 @@ class MsbuildResolver implements IExecutableResolver {
         def proc = vswhere.start()
         proc.waitFor()
         def location = proc.in.text?.trim();
-        if (location) {
-            def msbuildDir = new File(location, 'MSBuild')
-            msbuild.logger.info("Found following MSBuild installation folder: ${msbuildDir}")
-            msbuildDir.eachDirMatch(~/\d+(\.\d+)*/) { dir ->
-                msbuild.msbuildDir = new File(dir, 'Bin')
-                return
-            }
+        if (!location) {
+            return
+        }
+        def msbuildDir = new File(location, 'MSBuild')
+        if (!msbuildDir.exists()) {
+            return
+        }
+        msbuild.logger.info("Found following MSBuild installation folder: ${msbuildDir}")
+        msbuildDir.eachDirMatch(~/\d+(\.\d+)*/) { dir ->
+            msbuild.msbuildDir = new File(dir, 'Bin')
+            return
         }
     }
 


### PR DESCRIPTION
if msbuild version < 15 is set, -legacy will have to be added for vswhere
command but the installation folder does not follow the same pattern
i.e. {return}\Msbuild\bin\msbuild.exe but {return}\bin\msbuild.exe

keep using the findMsbuildFromRegistry in case the return from vswhere
does not exist for legacy msbuild

To fix #92