### PR TITLE
Ensure we use local installed MsBuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: csharp
 script:
   - ./gradlew -is --console plain build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gradle-msbuild-plugin changelog
 
+# 2.23
+### Changes
+* Update for VS 2017 to use local installed MsBuild (VS no longer installs assemblies in GAC.)
+
 ## 2.22
 ### Fixed
 * Upgrade download-task to fix expires header parsing

--- a/ProjectFileParser.sln
+++ b/ProjectFileParser.sln
@@ -1,11 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectFileParser", "src\main\dotnet\ProjectFileParser\ProjectFileParser.csproj", "{BB8169E4-9D52-49A1-A097-C300B9446483}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectFileParser_Tests", "src\main\dotnet\ProjectFileParser_Tests\ProjectFileParser_Tests.csproj", "{067456C0-086C-46A8-B37F-1405717B7BFC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5246248C-62BF-40AA-A8CB-21FB31BE78B4}"
+	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +30,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F4EDF9BE-2BF8-4EE1-8E26-6746CD5CB0FA}
 	EndGlobalSection
 EndGlobal

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,8 @@ nunit.dependsOn msbuild
 task generateZip(dependsOn: nunit, type: Zip) {
     from (msbuild.mainProject.properties.TargetDir) {
         include '*.exe'
-        include '*.dll'
-        include '*.targets'
-        include '*.props'
+        include '**/*.dll'
+        include '*.config'
     }
     into '/'
     archiveName 'ProjectFileParser.zip'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.23
+version = 3.0

--- a/src/main/dotnet/ProjectFileParser/MSBuildCustomLocator.cs
+++ b/src/main/dotnet/ProjectFileParser/MSBuildCustomLocator.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Microsoft.Build.Locator;
+﻿using Microsoft.Build.Locator;
+using System;
 
 namespace ProjectFileParser
 {
@@ -13,8 +13,8 @@ namespace ProjectFileParser
             }
             catch (InvalidOperationException ex)
             {
-                Console.WriteLine("MSBuildLocator cannot detect VS location, falling back to GAC register MSBuild dlls");
-                Console.WriteLine("Error was: {0}", ex);
+                Console.Error.WriteLine("MSBuildLocator cannot detect VS location, falling back to GAC register MSBuild dlls");
+                Console.Error.WriteLine("Error was: {0}", ex);
 
                 RegisterFallback();
             }

--- a/src/main/dotnet/ProjectFileParser/MSBuildCustomLocator.cs
+++ b/src/main/dotnet/ProjectFileParser/MSBuildCustomLocator.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.Build.Locator;
+
+namespace ProjectFileParser
+{
+    internal static class MSBuildCustomLocator
+    {
+        public static void Register()
+        {
+            try
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.WriteLine("MSBuildLocator cannot detect VS location, falling back to GAC register MSBuild dlls");
+                Console.WriteLine("Error was: {0}", ex);
+
+                RegisterFallback();
+            }
+        }
+
+        private static void RegisterFallback()
+        {
+            AppDomain.CurrentDomain.AppendPrivatePath("privateDlls");
+        }
+    }
+}

--- a/src/main/dotnet/ProjectFileParser/Program.cs
+++ b/src/main/dotnet/ProjectFileParser/Program.cs
@@ -3,7 +3,6 @@ using System.IO;
 using Microsoft.Build.Construction;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace ProjectFileParser
 {
@@ -11,11 +10,14 @@ namespace ProjectFileParser
     {
         static int Main(string[] args)
         {
+            MSBuildCustomLocator.Register();
+
             using (new MonoHack())
             {
                 try
                 {
-                    var obj = JObject.Parse(Console.In.ReadToEnd());
+                    var customPropertiesText = "{}";//Console.In.ReadToEnd();
+                    var obj = JObject.Parse(customPropertiesText);
                     var result = Parse(args[0], obj);
                     Console.WriteLine(result.ToString());
                 }

--- a/src/main/dotnet/ProjectFileParser/Program.cs
+++ b/src/main/dotnet/ProjectFileParser/Program.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.IO;
-using Microsoft.Build.Construction;
+﻿using Microsoft.Build.Construction;
 using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace ProjectFileParser
 {
-    class Program
+    internal class Program
     {
-        static int Main(string[] args)
+        private static int Main(string[] args)
         {
             MSBuildCustomLocator.Register();
 
@@ -16,10 +16,10 @@ namespace ProjectFileParser
             {
                 try
                 {
-                    var customPropertiesText = "{}";//Console.In.ReadToEnd();
+                    var customPropertiesText = Console.In.ReadToEnd();
                     var obj = JObject.Parse(customPropertiesText);
                     var result = Parse(args[0], obj);
-                    Console.WriteLine(result.ToString());
+                    Console.WriteLine(result);
                 }
                 catch (Exception e)
                 {
@@ -30,25 +30,25 @@ namespace ProjectFileParser
             return 0;
         }
 
-        static JObject Parse(string file, JObject args)
+        private static JObject Parse(string file, JObject args)
         {
             var isSolution = Path.GetExtension(file).Equals(".sln", StringComparison.InvariantCultureIgnoreCase);
             return isSolution ? ParseSolution(file, args) : ParseProject(file, args);
         }
 
-        static JObject ParseSolution(string file, JObject args)
+        private static JObject ParseSolution(string file, JObject args)
         {
             var projects = ProjectHelpers.GetProjects(SolutionFile.Parse(file), ParamsToDic(args));
             return Jsonify.ToJson(projects);
         }
 
-        static JObject ParseProject(string file, JObject args)
+        private static JObject ParseProject(string file, JObject args)
         {
             var project = ProjectHelpers.LoadProject(file, ParamsToDic(args));
             return Jsonify.ToJson(project);
         }
 
-        static IDictionary<string, string> ParamsToDic(JObject args)
+        private static IDictionary<string, string> ParamsToDic(JObject args)
         {
             var dic = new Dictionary<string, string>();
             foreach (var kvp in args)

--- a/src/main/dotnet/ProjectFileParser/ProjectFileParser.csproj
+++ b/src/main/dotnet/ProjectFileParser/ProjectFileParser.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -45,54 +47,59 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Build.15.6.82\lib\net46\Microsoft.Build.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\Microsoft.Build.15.9.20\lib\net46\Microsoft.Build.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Build.Framework.15.6.82\lib\net46\Microsoft.Build.Framework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\Microsoft.Build.Framework.15.9.20\lib\net46\Microsoft.Build.Framework.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Build.Utilities.Core.15.6.82\lib\net46\Microsoft.Build.Utilities.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Build.Locator.1.1.2\lib\net46\Microsoft.Build.Locator.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Interop.1.16.30\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=3.0.0.34420, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.3.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard1.3\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.Process, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.Process.4.1.0\lib\net46\System.Diagnostics.Process.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.Process.4.3.0\lib\net46\System.Diagnostics.Process.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Threading.Tasks.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Threading.Tasks.Dataflow.4.9.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonoHack.cs" />
+    <Compile Include="MSBuildCustomLocator.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Jsonify.cs" />
     <Compile Include="ProjectHelpers.cs" />
@@ -110,8 +117,31 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\packages\Microsoft.Build.15.9.20\lib\net46\Microsoft.Build.dll">
+      <Link>privateDlls\Microsoft.Build.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\..\packages\Microsoft.Build.Framework.15.9.20\lib\net46\Microsoft.Build.Framework.dll">
+      <Link>privateDlls\Microsoft.Build.Framework.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\..\packages\Microsoft.Build.Utilities.Core.15.9.20\lib\net46\Microsoft.Build.Utilities.Core.dll">
+      <Link>privateDlls\Microsoft.Build.Utilities.Core.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(TargetFiles)" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+  </Target>
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/main/dotnet/ProjectFileParser/packages.config
+++ b/src/main/dotnet/ProjectFileParser/packages.config
@@ -1,25 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Build" version="15.6.82" targetFramework="net46" />
-  <package id="Microsoft.Build.Framework" version="15.6.82" targetFramework="net46" />
-  <package id="Microsoft.Build.Utilities.Core" version="15.6.82" targetFramework="net46" />
-  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="Microsoft.Build" version="15.9.20" targetFramework="net46" />
+  <package id="Microsoft.Build.Framework" version="15.9.20" targetFramework="net46" />
+  <package id="Microsoft.Build.Locator" version="1.1.2" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.16.30" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Web.Xdt" version="3.0.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net46" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
-  <package id="System.Diagnostics.Process" version="4.1.0" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
-  <package id="System.ObjectModel" version="4.0.12" targetFramework="net46" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net46" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net451" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Process" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Dataflow" version="4.5.24" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Parallel" version="4.0.1" targetFramework="net46" />
-  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/src/main/dotnet/ProjectFileParser_Tests/ProjectFileParser_Tests.csproj
+++ b/src/main/dotnet/ProjectFileParser_Tests/ProjectFileParser_Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,51 +35,55 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Build.15.6.82\lib\net46\Microsoft.Build.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.Build.15.9.20\lib\net46\Microsoft.Build.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Build.Framework.15.6.82\lib\net46\Microsoft.Build.Framework.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.Build.Framework.15.9.20\lib\net46\Microsoft.Build.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Build.Utilities.Core.15.6.82\lib\net46\Microsoft.Build.Utilities.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\Microsoft.Build.Utilities.Core.15.9.20\lib\net46\Microsoft.Build.Utilities.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Interop.1.16.30\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=3.0.0.34420, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.3.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard1.3\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Diagnostics.Process, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Diagnostics.Process.4.1.0\lib\net46\System.Diagnostics.Process.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\packages\System.Diagnostics.Process.4.3.0\lib\net46\System.Diagnostics.Process.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Threading.Tasks.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Threading.Tasks.Dataflow.4.9.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xaml" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
@@ -84,6 +91,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Resources\packages.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -127,5 +135,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(TargetFiles)" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\NUnit.3.11.0\build\NUnit.props'))" />
   </Target>
 </Project>

--- a/src/main/dotnet/ProjectFileParser_Tests/app.config
+++ b/src/main/dotnet/ProjectFileParser_Tests/app.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/main/dotnet/ProjectFileParser_Tests/packages.config
+++ b/src/main/dotnet/ProjectFileParser_Tests/packages.config
@@ -1,26 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Build" version="15.6.82" targetFramework="net46" />
-  <package id="Microsoft.Build.Framework" version="15.6.82" targetFramework="net46" />
-  <package id="Microsoft.Build.Utilities.Core" version="15.6.82" targetFramework="net46" />
-  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="Microsoft.Build" version="15.9.20" targetFramework="net46" />
+  <package id="Microsoft.Build.Framework" version="15.9.20" targetFramework="net46" />
+  <package id="Microsoft.Build.Utilities.Core" version="15.9.20" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.16.30" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Web.Xdt" version="3.0.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net46" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net451" />
-  <package id="NUnit" version="3.6.1" targetFramework="net451" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net451" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
-  <package id="System.Diagnostics.Process" version="4.1.0" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
-  <package id="System.ObjectModel" version="4.0.12" targetFramework="net46" />
-  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net46" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net451" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net451" />
+  <package id="NUnit" version="3.11.0" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Process" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Dataflow" version="4.5.24" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Parallel" version="4.0.1" targetFramework="net46" />
-  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -89,6 +89,13 @@ class Msbuild extends ConventionTask {
         ZipEntry ze = zis.getNextEntry()
         while (ze != null) {
             String fileName = ze.getName()
+            if (ze.isDirectory()) {
+                File subFolder = new File(tempDir, fileName)
+                subFolder.mkdir()
+                subFolder.deleteOnExit()
+                ze = zis.getNextEntry()
+                continue
+            }
             File target = new File(tempDir, fileName)
             target.newOutputStream().leftShift(zis).close()
             target.deleteOnExit()

--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -108,17 +108,31 @@ class Msbuild extends ConventionTask {
         def builder = resolver.executeDotNet(executable)
         builder.command().add(file.toString())
         def proc = builder.start()
+
         def stderrBuffer = new StringBuffer()
         proc.consumeProcessErrorStream(stderrBuffer)
+        def stdoutBuffer = new StringBuffer()
+        proc.consumeProcessErrorStream(stdoutBuffer)
+
         try {
-            proc.out.leftShift(JsonOutput.toJson(getInitProperties())).close()
+            def initPropertiesJson = JsonOutput.toJson(getInitProperties())
+            logger.debug "Sending ${initPropertiesJson} to ProjectFileParser"
+            proc.out.leftShift(initPropertiesJson).close()
             return new JsonSlurper().parseText(new FilterJson(proc.in).toString())
         }
         finally {
-            if (proc.waitFor() != 0) {
-                stderrBuffer.eachLine { line ->
+            def hasErrors = proc.waitFor() != 0
+            logger.debug "Output from ProjectFileParser: "
+            stdoutBuffer.eachLine { line ->
+                 logger.debug line
+            }
+            stderrBuffer.eachLine { line ->
+                if (hasErrors)
                     logger.error line
-                }
+                else
+                    logger.debug line
+            }
+            if (hasErrors) {
                 throw new GradleException('Project file parsing failed')
             }
         }

--- a/src/main/groovy/com/ullink/MsbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/MsbuildResolver.groovy
@@ -37,7 +37,7 @@ class MsbuildResolver implements IExecutableResolver {
         if (!msbuildDir.exists()) {
             return
         }
-        msbuild.logger.info("Found following MSBuild installation folder: ${msbuildDir}")
+        msbuild.logger.info("Found following MSBuild(vswhere) installation folder: ${msbuildDir}")
         msbuildDir.eachDirMatch(~/\d+(\.\d+)*/) { dir ->
             msbuild.msbuildDir = new File(dir, 'Bin')
             return
@@ -48,7 +48,7 @@ class MsbuildResolver implements IExecutableResolver {
         List<String> availableVersions =
             getMsBuildVersionsFromRegistry(MSBUILD_WOW6432_PREFIX) +
             getMsBuildVersionsFromRegistry(MSBUILD_PREFIX)
-        msbuild.logger.debug("Found following MSBuild versions in the registry: ${availableVersions}")
+        msbuild.logger.debug("Found following MSBuild(registry) versions in the registry: ${availableVersions}")
 
         List<String> versionsToCheck
         if (msbuild.version != null) {

--- a/src/main/groovy/com/ullink/MsbuildResolver.groovy
+++ b/src/main/groovy/com/ullink/MsbuildResolver.groovy
@@ -37,7 +37,7 @@ class MsbuildResolver implements IExecutableResolver {
         if (!msbuildDir.exists()) {
             return
         }
-        msbuild.logger.info("Found following MSBuild(vswhere) installation folder: ${msbuildDir}")
+        msbuild.logger.info("Found the following MSBuild (using vswhere) installation folder: ${msbuildDir}")
         msbuildDir.eachDirMatch(~/\d+(\.\d+)*/) { dir ->
             msbuild.msbuildDir = new File(dir, 'Bin')
             return
@@ -48,7 +48,7 @@ class MsbuildResolver implements IExecutableResolver {
         List<String> availableVersions =
             getMsBuildVersionsFromRegistry(MSBUILD_WOW6432_PREFIX) +
             getMsBuildVersionsFromRegistry(MSBUILD_PREFIX)
-        msbuild.logger.debug("Found following MSBuild(registry) versions in the registry: ${availableVersions}")
+        msbuild.logger.debug("Found the following MSBuild (in the registry) versions: ${availableVersions}")
 
         List<String> versionsToCheck
         if (msbuild.version != null) {


### PR DESCRIPTION
Use MSBuildLocator to load the local installed MsBuild and do not distribute the compile type referenced MsBuild libs.  
This is needed in order to avoid using older MsBuild versions from GAC as new VS versions don't install assemblies in GAC.

Notes:

• Works only with VS 2017 and later!
• Had to manually remove the props & targets files included by the Locator package due to backward compatibility with msbuild (see Microsoft/MSBuildLocator#52)
• tests are not using locator as AppVeyor is building using MsBuild 14, so using locator would fail the tests there