### PR TITLE
Fail elegantly if no project is parsed

### DIFF
--- a/src/main/groovy/com/ullink/Msbuild.groovy
+++ b/src/main/groovy/com/ullink/Msbuild.groovy
@@ -73,6 +73,9 @@ class Msbuild extends ConventionTask {
     ProjectFileParser getMainProject() {
         if (resolveProject()) {
             projectParsed
+        } else {
+            logger.warn "Main project was resolved to null due to a parse error. The .sln file might be missing or incorrectly named."
+            throw new GradleException("Failed to resolve main project. Make sure the name of the .sln file matches the one of the repository")
         }
     }
 
@@ -159,6 +162,7 @@ class Msbuild extends ConventionTask {
                 projectParsed = allProjects.values().first()
             }
         }
+        logger.warn "Parsed project is null (not a solution / project build)"
         projectParsed != null
     }
 


### PR DESCRIPTION
 - thus avoiding NPE when calling getMainProject

Issue: PTIS-1080
Change-Id: If8d0d511408cc2bca7542d05245293f760e652a7